### PR TITLE
Add advanced CORS headers

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -16,15 +16,19 @@ class Handler(RESTHandler):
         self.logger = blk.logger
 
     def on_get(self, req, rsp):
+        self.__add_cors(rsp)
         self.run_request('GET', req, rsp, include_body=False)
 
     def on_post(self, req, rsp):
+        self.__add_cors(rsp)
         self.run_request('POST', req, rsp, include_body=True)
 
     def on_put(self, req, rsp):
+        self.__add_cors(rsp)
         self.run_request('PUT', req, rsp, include_body=True)
 
     def on_delete(self, req, rsp):
+        self.__add_cors(rsp)
         self.run_request('DELETE', req, rsp, include_body=False)
 
     def on_options(self, req, rsp):

--- a/handler.py
+++ b/handler.py
@@ -9,30 +9,30 @@ class Handler(RESTHandler):
 
     """ A REST Handler that will listen for HTTP requests and register them """
 
-    def __init__(self, endpoint, cors, blk):
+    def __init__(self, endpoint, blk, headers=None):
         super().__init__('/' + endpoint)
         self._blk = blk
-        self._cors = cors
         self.logger = blk.logger
+        self._headers = headers
 
     def on_get(self, req, rsp):
-        self.__add_cors(rsp)
+        self.__add_headers(rsp)
         self.run_request('GET', req, rsp, include_body=False)
 
     def on_post(self, req, rsp):
-        self.__add_cors(rsp)
+        self.__add_headers(rsp)
         self.run_request('POST', req, rsp, include_body=True)
 
     def on_put(self, req, rsp):
-        self.__add_cors(rsp)
+        self.__add_headers(rsp)
         self.run_request('PUT', req, rsp, include_body=True)
 
     def on_delete(self, req, rsp):
-        self.__add_cors(rsp)
+        self.__add_headers(rsp)
         self.run_request('DELETE', req, rsp, include_body=False)
 
     def on_options(self, req, rsp):
-        self.__add_cors(rsp)
+        self.__add_headers(rsp)
 
     def run_request(self, method, req, rsp, include_body=False):
         """ Record an HTTP request for a given method """
@@ -100,31 +100,10 @@ class Handler(RESTHandler):
         rsp.set_status(501)
         return False
 
-    def __add_cors(self, rsp):
-        allow_origin = self._cors.allow_origin()
-        if allow_origin is not None:
-            rsp.set_header("Access-Control-Allow-Origin", allow_origin)
-
-        allow_credentials = self._cors.allow_credentials()
-        if allow_credentials is not None:
-            rsp.set_header("Access-Control-Allow-Credentials", allow_credentials)
-
-        max_age = self._cors.max_age()
-        if max_age is not None:
-            rsp.set_header("Access-Control-Max-Age", max_age)
-
-        expose_headers = self._cors.expose_headers()
-        if expose_headers is not None:
-            rsp.set_header("Access-Control-Expose-Headers", expose_headers)
-
-        allow_methods = self._cors.allow_methods()
-        if allow_methods is not None:
-            rsp.set_header("Access-Control-Allow-Methods", allow_methods)
-
-        allow_headers = self._cors.allow_headers()
-        if allow_headers is not None:
-            rsp.set_header("Access-Control-Allow-Headers", allow_headers)
-
+    def __add_headers(self, rsp):
+        if self._headers is not None:
+            for header in self._headers:
+                rsp.set_header(header, self._headers[header])
 
 class JSONHandler(Handler):
 

--- a/handler.py
+++ b/handler.py
@@ -9,9 +9,10 @@ class Handler(RESTHandler):
 
     """ A REST Handler that will listen for HTTP requests and register them """
 
-    def __init__(self, endpoint, blk):
+    def __init__(self, endpoint, cors, blk):
         super().__init__('/' + endpoint)
         self._blk = blk
+        self._cors = cors
         self.logger = blk.logger
 
     def on_get(self, req, rsp):
@@ -27,8 +28,7 @@ class Handler(RESTHandler):
         self.run_request('DELETE', req, rsp, include_body=False)
 
     def on_options(self, req, rsp):
-        # Don't do anything except simply handle OPTIONS requests for CORS
-        pass
+        self.__add_cors(rsp)
 
     def run_request(self, method, req, rsp, include_body=False):
         """ Record an HTTP request for a given method """
@@ -95,6 +95,31 @@ class Handler(RESTHandler):
 
         rsp.set_status(501)
         return False
+
+    def __add_cors(self, rsp):
+        allow_origin = self._cors.allow_origin()
+        if allow_origin is not None:
+            rsp.set_header("Access-Control-Allow-Origin", allow_origin)
+
+        allow_credentials = self._cors.allow_credentials()
+        if allow_credentials is not None:
+            rsp.set_header("Access-Control-Allow-Credentials", allow_credentials)
+
+        max_age = self._cors.max_age()
+        if max_age is not None:
+            rsp.set_header("Access-Control-Max-Age", max_age)
+
+        expose_headers = self._cors.expose_headers()
+        if expose_headers is not None:
+            rsp.set_header("Access-Control-Expose-Headers", expose_headers)
+
+        allow_methods = self._cors.allow_methods()
+        if allow_methods is not None:
+            rsp.set_header("Access-Control-Allow-Methods", allow_methods)
+
+        allow_headers = self._cors.allow_headers()
+        if allow_headers is not None:
+            rsp.set_header("Access-Control-Allow-Headers", allow_headers)
 
 
 class JSONHandler(Handler):

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -16,3 +16,21 @@ class TestHandler(NIOBlockTestCase):
     def test_handler_options(self):
         handler = Handler(endpoint='', blk=MagicMock(spec=WebHandler()))
         handler.on_options(MagicMock(), MagicMock())
+
+    def test_handler_headers(self):
+        """ Handler should add optional headers to all request types """
+        headers = {
+            "Access-Control-Allow-Origin": "https://app.local:3000"
+        }
+
+        handler = Handler(endpoint='',
+                          blk=MagicMock(spec=WebHandler()),
+                          headers=headers)
+
+        handler.run_request = MagicMock()
+
+        for method in ['on_get','on_post','on_put','on_delete','on_options']:
+            resp=MagicMock()
+            getattr(handler, method)(MagicMock(), resp)
+            self.assertEqual(resp.set_header.call_args[0],
+                            ('Access-Control-Allow-Origin', 'https://app.local:3000'))

--- a/tests/test_web_handler_block.py
+++ b/tests/test_web_handler_block.py
@@ -43,3 +43,31 @@ class TestWebHandler(NIOBlockTestCase):
                 'auth': False
             })
         self.assertEqual(Handler.before_handler, blk._no_auth)
+
+    @patch(WebHandler.__module__ + ".WebEngine")
+    @patch(WebHandler.__module__ + ".Handler")
+    def test_adding_cors_headers(self, MockHandler, MockWebHandler):
+        """ Test that the block adds CORS headers as defined in block config"""
+        blk = WebHandler()
+        self.configure_block(blk, {
+            'cors': {
+                'allow_origin': 'http://app.local',
+                'allow_headers': 'Nio-Header, App-Header'
+            }
+        })
+        self.assertEqual(MockHandler.call_count, 1)
+        args, kwargs = MockHandler.call_args
+        self.assertEqual(kwargs['headers'], {
+            'Access-Control-Allow-Origin': 'http://app.local',
+            'Access-Control-Allow-Headers': 'Nio-Header, App-Header'
+        })
+
+    @patch(WebHandler.__module__ + ".WebEngine")
+    @patch(WebHandler.__module__ + ".Handler")
+    def test_no_cors_headers(self, MockHandler, MockWebHandler):
+        """ Test that the block addsno  CORS headers if empty"""
+        blk = WebHandler()
+        self.configure_block(blk, {})
+        self.assertEqual(MockHandler.call_count, 1)
+        args, kwargs = MockHandler.call_args
+        self.assertEqual(kwargs['headers'], {})

--- a/web_handler_block.py
+++ b/web_handler_block.py
@@ -48,7 +48,7 @@ class WebHandler(GeneratorBlock):
 
     cors = ObjectProperty(CORS,
                           title="Access-Control Headers",
-                          default=dict(),
+                          default=CORS(),
                           advanced=True)
 
     def configure(self, context):

--- a/web_handler_block.py
+++ b/web_handler_block.py
@@ -8,10 +8,10 @@ from nio.properties import StringProperty, IntProperty, VersionProperty, \
 
 class CORS(PropertyHolder):
     allow_origin = StringProperty(title='Access-Control-Allow-Origin',
-                                  default='*',
+                                  default=None,
                                   allow_none=True)
     allow_credentials = StringProperty(title='Access-Control-Allow-Credentials',
-                                  default='true',
+                                  default=None,
                                   allow_none=True)
     max_age = StringProperty(title='Access-Control-Max-Age',
                                   default=None,
@@ -20,10 +20,10 @@ class CORS(PropertyHolder):
                                   default=None,
                                   allow_none=True)
     allow_methods = StringProperty(title='Access-Control-Allow-Methods',
-                                  default='GET,POST,PUT,DELETE,OPTIONS',
+                                  default=None,
                                   allow_none=True)
     allow_headers = StringProperty(title='Access-Control-Allow-Headers',
-                                  default='Accept, Origin, Content-Type, Authorization',
+                                  default=None,
                                   allow_none=True)
 
 class WebHandler(GeneratorBlock):

--- a/web_handler_block.py
+++ b/web_handler_block.py
@@ -76,22 +76,22 @@ class WebHandler(GeneratorBlock):
 
         headers = dict()
 
-        if allow_origin is not None:
+        if allow_origin:
             headers["Access-Control-Allow-Origin"] = allow_origin
 
-        if allow_credentials is not None:
+        if allow_credentials:
             headers["Access-Control-Allow-Credentials"] = allow_credentials
 
-        if max_age is not None:
+        if max_age:
             headers["Access-Control-Max-Age"] = max_age
 
-        if expose_headers is not None:
+        if expose_headers:
             headers["Access-Control-Expose-Headers"] = expose_headers
 
-        if allow_methods is not None:
+        if allow_methods:
             headers["Access-Control-Allow-Methods"] = allow_methods
 
-        if allow_headers is not None:
+        if allow_headers:
             headers["Access-Control-Allow-Headers"] = allow_headers
 
         return Handler(self.endpoint(), blk=self, headers=headers)

--- a/web_handler_block.py
+++ b/web_handler_block.py
@@ -3,8 +3,28 @@ from .handler import Handler, JSONHandler
 from nio import GeneratorBlock
 from nio.modules.web import WebEngine
 from nio.properties import StringProperty, IntProperty, VersionProperty, \
-                           TimeDeltaProperty, BoolProperty
+                           ObjectProperty, TimeDeltaProperty, BoolProperty, \
+                           PropertyHolder
 
+class CORS(PropertyHolder):
+    allow_origin = StringProperty(title='Access-Control-Allow-Origin',
+                                  default='*',
+                                  allow_none=True)
+    allow_credentials = StringProperty(title='Access-Control-Allow-Credentials',
+                                  default='true',
+                                  allow_none=True)
+    max_age = StringProperty(title='Access-Control-Max-Age',
+                                  default=None,
+                                  allow_none=True)
+    expose_headers = StringProperty(title='Access-Control-Expose-Headers',
+                                  default=None,
+                                  allow_none=True)
+    allow_methods = StringProperty(title='Access-Control-Allow-Methods',
+                                  default='GET,POST,PUT,DELETE,OPTIONS',
+                                  allow_none=True)
+    allow_headers = StringProperty(title='Access-Control-Allow-Headers',
+                                  default='Accept, Origin, Content-Type, Authorization',
+                                  allow_none=True)
 
 class WebHandler(GeneratorBlock):
 
@@ -26,6 +46,11 @@ class WebHandler(GeneratorBlock):
                              default='',
                              allow_none=True)
 
+    cors = ObjectProperty(CORS,
+                          title="Access-Control Headers",
+                          default=dict(),
+                          advanced=True)
+
     def configure(self, context):
         super().configure(context)
         config = {}
@@ -42,7 +67,7 @@ class WebHandler(GeneratorBlock):
         self._server.add_handler(self.get_handler())
 
     def get_handler(self):
-        return Handler(self.endpoint(), self)
+        return Handler(self.endpoint(), self.cors(), self)
 
     def __init__(self):
         super().__init__()

--- a/web_handler_block.py
+++ b/web_handler_block.py
@@ -67,7 +67,34 @@ class WebHandler(GeneratorBlock):
         self._server.add_handler(self.get_handler())
 
     def get_handler(self):
-        return Handler(self.endpoint(), self.cors(), self)
+        allow_origin = self.cors().allow_origin()
+        allow_credentials = self.cors().allow_credentials()
+        max_age = self.cors().max_age()
+        expose_headers = self.cors().expose_headers()
+        allow_methods = self.cors().allow_methods()
+        allow_headers = self.cors().allow_headers()
+
+        headers = dict()
+
+        if allow_origin is not None:
+            headers["Access-Control-Allow-Origin"] = allow_origin
+
+        if allow_credentials is not None:
+            headers["Access-Control-Allow-Credentials"] = allow_credentials
+
+        if max_age is not None:
+            headers["Access-Control-Max-Age"] = max_age
+
+        if expose_headers is not None:
+            headers["Access-Control-Expose-Headers"] = expose_headers
+
+        if allow_methods is not None:
+            headers["Access-Control-Allow-Methods"] = allow_methods
+
+        if allow_headers is not None:
+            headers["Access-Control-Allow-Headers"] = allow_headers
+
+        return Handler(self.endpoint(), blk=self, headers=headers)
 
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
This PR introduces an Advanced object property on Handlers, to define CORS related headers. These headers are added to _all_ requests, but are namely valuable when dealing with browser AJAX requests that send a preflight `OPTIONS` request before the _actual_ request.