### PR TITLE
use a JSON-safe id for requests

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -43,7 +43,7 @@ class Handler(RESTHandler):
             return
 
         # Generate a unique ID for this request
-        request_id = uuid4()
+        request_id = str(uuid4())
 
         # Register this request with the broker
         self.logger.debug(

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -65,7 +65,7 @@ class TestBroker(NIOBlockTestCase):
 
     def register_request(self, timeout):
         """ Register a request in a new thread and return the ID and resp """
-        req_id = uuid4()
+        req_id = str(uuid4())
         mock_rsp = self.get_mocked_response()
         mock_req = self.get_mocked_request()
         RequestResponseBroker.register_request(


### PR DESCRIPTION
This uses a JSON-safe id for requests. This should make it easier to pass a request through Pub/Sub.